### PR TITLE
Added CNF and SAT serialization support

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/items.rs
+++ b/src/items.rs
@@ -34,7 +34,7 @@ impl ToString for Sign {
     fn to_string(&self) -> String {
         match self {
             Sign::Pos => String::from(""),
-            Sign::Neg => String::from("-")
+            Sign::Neg => String::from("-"),
         }
     }
 }
@@ -73,7 +73,6 @@ impl ToString for Lit {
         self.to_i64().to_string()
     }
 }
-
 
 /// Represents a clause instance within a `.cnf` file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,13 +218,15 @@ pub enum Instance {
 impl ToString for Instance {
     fn to_string(&self) -> String {
         match self {
-            Instance::Cnf {num_vars, clauses} =>
-                Instance::cnf_to_string(*num_vars, clauses),
-            Instance::Sat {num_vars, extensions, formula} => {
-                Instance::sat_to_string(*num_vars, extensions, formula)
-            },
+            Instance::Cnf { num_vars, clauses } => {
+                Instance::cnf_to_string(*num_vars, clauses)
+            }
+            Instance::Sat {
+                num_vars,
+                extensions,
+                formula,
+            } => Instance::sat_to_string(*num_vars, extensions, formula),
         }
-
     }
 }
 
@@ -240,7 +241,11 @@ impl Instance {
 
     /// Creates a new SAT instance for `.sat` files with given extensions and
     /// an underlying formula.
-    pub fn sat(num_vars: u64, extensions: Extensions, formula: Formula) -> Instance {
+    pub fn sat(
+        num_vars: u64,
+        extensions: Extensions,
+        formula: Formula,
+    ) -> Instance {
         Instance::Sat {
             num_vars,
             extensions,
@@ -248,8 +253,11 @@ impl Instance {
         }
     }
 
-    fn sat_to_string(num_vars: u64, extensions: &Extensions,
-                     formula: &Formula) -> String {
+    fn sat_to_string(
+        num_vars: u64,
+        extensions: &Extensions,
+        formula: &Formula,
+    ) -> String {
         let problem = format!("p {} {}", extensions.to_string(), num_vars);
         let formula = formula.to_string();
         format!("{}\n{}\n", problem, formula)
@@ -260,8 +268,11 @@ impl Instance {
             let key = format!("p cnf {} {}\n", num_vars, clauses.len());
             let clauses = clauses.iter().map(|clause| {
                 let cmap = clause.lits().iter().map(|lit| {
-                    let sign = String::from(
-                        if lit.sign() == Sign::Neg { "-" }  else { "" });
+                    let sign = String::from(if lit.sign() == Sign::Neg {
+                        "-"
+                    } else {
+                        ""
+                    });
                     format!("{}{}", sign, lit.var().to_u64().to_string())
                 });
                 let cvec: Vec<String> = cmap.collect();
@@ -279,9 +290,8 @@ impl Instance {
     /// `comments` is a list of comments which are inserted into the
     /// beginning of the resulting String.
     pub fn serialize(&self, comments: &Vec<String>) -> String {
-        let comments: Vec<String> = comments.iter()
-                .map(|x| format!("c {}", x))
-                .collect();
+        let comments: Vec<String> =
+            comments.iter().map(|x| format!("c {}", x)).collect();
         let comments: String = comments.join("\n");
 
         let body = self.to_string();
@@ -309,9 +319,9 @@ impl ToString for Extensions {
         } else {
             String::from(match *self {
                 Extensions::NONE => "sat",
-                Extensions::XOR  => "satx",
-                Extensions::EQ   => "sate",
-                _ => "Illegal extension"
+                Extensions::XOR => "satx",
+                Extensions::EQ => "sate",
+                _ => "Illegal extension",
             })
         }
     }

--- a/src/items.rs
+++ b/src/items.rs
@@ -160,11 +160,11 @@ impl Display for Formula {
             | Formula::Xor(formula_list)
             | Formula::Eq(formula_list) => {
                 let fl = formula_list;
-                for formula in fl[0..fl.len() - 1].iter() {
-                    write!(f, "{} ", formula)?;
-                }
-                if !fl.is_empty() {
-                    write!(f, "{}", fl.last().unwrap())?;
+                if let Some((last, rest)) = fl.split_last() {
+                    for formula in rest {
+                        write!(f, "{} ", formula)?;
+                    }
+                    write!(f, "{}", last)?;
                 }
                 write!(f, ")")?;
             }
@@ -303,7 +303,7 @@ impl Instance {
     /// beginning of the resulting String.
     pub fn serialize<O: core::fmt::Write>(
         &self,
-        comments: &[String],
+        comments: &[&str],
         output: &mut O,
     ) -> core::fmt::Result {
         for comment in comments {

--- a/src/items.rs
+++ b/src/items.rs
@@ -3,13 +3,6 @@
 
 use std::fmt::Display;
 
-#[cfg(windows)]
-const LINE_ENDING: &str = "\r\n";
-
-#[cfg(not(windows))]
-const LINE_ENDING: &str = "\n";
-
-
 /// Represents a variable within a SAT instance.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Var(pub u64);
@@ -308,13 +301,16 @@ impl Instance {
     /// Creates a SAT or CNF instance, converting it into a String
     /// `comments` is a list of comments which are inserted into the
     /// beginning of the resulting String.
-    pub fn serialize(&self, comments: &[String]) -> String {
-        let comments: Vec<String> =
-            comments.iter().map(|x| format!("c {}", x)).collect();
-        let comments: String = comments.join(LINE_ENDING);
+    pub fn serialize<O: core::fmt::Write>(
+        &self,
+        comments: &[String],
+        output: &mut O,
+    ) -> core::fmt::Result {
+        for comment in comments {
+            writeln!(output, "c {}", comment)?;
+        }
 
-        let body = self.to_string();
-        format!("{}{}{}{}", comments, LINE_ENDING, body, LINE_ENDING)
+        writeln!(output, "{}", self)
     }
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -171,8 +171,9 @@ impl Display for Formula {
                     write!(f, "{} ", formula)?;
                 }
                 if !fl.is_empty() {
-                    write!(f, "{})", fl.last().unwrap())?;
+                    write!(f, "{}", fl.last().unwrap())?;
                 }
+                write!(f, ")")?;
             }
         }
         Ok(())

--- a/src/items.rs
+++ b/src/items.rs
@@ -1,7 +1,7 @@
 //! Some item definitions used in instances to provide a virtual representative
 //! structure of `.cnf` or `.sat` files and their associated clauses or formula.
 
-use std::string::ToString;
+use std::fmt::Display;
 
 /// Represents a variable within a SAT instance.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -14,9 +14,9 @@ impl Var {
     }
 }
 
-impl ToString for Var {
-    fn to_string(&self) -> String {
-        self.to_u64().to_string()
+impl Display for Var {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_u64())
     }
 }
 
@@ -30,12 +30,16 @@ pub enum Sign {
     Neg,
 }
 
-impl ToString for Sign {
-    fn to_string(&self) -> String {
-        match self {
-            Sign::Pos => String::from(""),
-            Sign::Neg => String::from("-"),
-        }
+impl Display for Sign {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Sign::Pos => "",
+                Sign::Neg => "-",
+            }
+        )
     }
 }
 
@@ -68,9 +72,9 @@ impl Lit {
     }
 }
 
-impl ToString for Lit {
-    fn to_string(&self) -> String {
-        self.to_i64().to_string()
+impl Display for Lit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_i64())
     }
 }
 
@@ -135,22 +139,42 @@ pub enum Formula {
     Eq(FormulaList),
 }
 
-impl ToString for Formula {
-    fn to_string(&self) -> String {
-        let fl_to_string = |fl: &FormulaList| {
-            let fv: Vec<String> = fl.iter().map(|x| x.to_string()).collect();
-            fv.join(" ")
-        };
+impl Display for Formula {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Prefix
         match self {
-            Formula::Lit(l) => l.to_string(),
-            Formula::Paren(f) => format!("({})", f.to_string()),
-            Formula::Neg(f) => format!("-{}", f.to_string()),
-            Formula::And(fl) => format!("*({})", fl_to_string(fl)),
-            Formula::Or(fl) => format!("+({})", fl_to_string(fl)),
-            Formula::Xor(fl) => format!("xor({})", fl_to_string(fl)),
-            Formula::Eq(fl) => format!("=({})", fl_to_string(fl)),
+            Formula::Lit(l) => write!(f, "{}", l)?,
+            Formula::Paren(m) => write!(f, "({})", m)?,
+            Formula::Neg(m) => write!(f, "-{}", m)?,
+            Formula::And(_) => write!(f, "*(")?,
+            Formula::Or(_) => write!(f, "+(")?,
+            Formula::Xor(_) => write!(f, "xor(")?,
+            Formula::Eq(_) => write!(f, "=(")?,
+        };
+
+        // Suffix
+        match self {
+            Formula::Lit(_) | Formula::Paren(_) | Formula::Neg(_) => {}
+            Formula::And(m)
+            | Formula::Or(m)
+            | Formula::Xor(m)
+            | Formula::Eq(m) => {
+                for idx in 0..(m.len() - 1) {
+                    write!(f, "{} ", m[idx])?;
+                }
+                if m.len() != 0 {
+                    write!(f, "{})", m[m.len() - 1])?;
+                } else {
+                    write!(f, ")")?;
+                }
+            }
         }
+        Ok(())
     }
+    // for idx in 0..ml.len() {
+    //     write!(f, "{} ", ml[idx])?;
+    // }
+    // write!(f, ") ")
 }
 
 impl Formula {
@@ -215,17 +239,17 @@ pub enum Instance {
     },
 }
 
-impl ToString for Instance {
-    fn to_string(&self) -> String {
+impl Display for Instance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Instance::Cnf { num_vars, clauses } => {
-                Instance::cnf_to_string(*num_vars, clauses)
+                Instance::fmt_cnf(f, *num_vars, clauses)
             }
             Instance::Sat {
                 num_vars,
                 extensions,
                 formula,
-            } => Instance::sat_to_string(*num_vars, extensions, formula),
+            } => Instance::fmt_sat(f, *num_vars, extensions, formula),
         }
     }
 }
@@ -253,37 +277,29 @@ impl Instance {
         }
     }
 
-    fn sat_to_string(
+    fn fmt_sat(
+        f: &mut std::fmt::Formatter<'_>,
         num_vars: u64,
         extensions: &Extensions,
         formula: &Formula,
-    ) -> String {
-        let problem = format!("p {} {}", extensions.to_string(), num_vars);
-        let formula = formula.to_string();
-        format!("{}\n{}\n", problem, formula)
+    ) -> std::fmt::Result {
+        write!(f, "p {} {}\n", extensions, num_vars)?;
+        write!(f, "{}\n", formula)
     }
 
-    fn cnf_to_string(num_vars: u64, clauses: &Box<[Clause]>) -> String {
-        let (clauses, key) = {
-            let key = format!("p cnf {} {}\n", num_vars, clauses.len());
-            let clauses = clauses.iter().map(|clause| {
-                let cmap = clause.lits().iter().map(|lit| {
-                    let sign = String::from(if lit.sign() == Sign::Neg {
-                        "-"
-                    } else {
-                        ""
-                    });
-                    format!("{}{}", sign, lit.var().to_u64().to_string())
-                });
-                let cvec: Vec<String> = cmap.collect();
-                let cstr = cvec.join(" ");
-                format!("{} 0", cstr)
-            });
-            let cvec: Vec<String> = clauses.collect();
-            let cstr = cvec.join("\n");
-            (cstr, key)
-        };
-        format!("{}{}\n", key, clauses)
+    fn fmt_cnf(
+        f: &mut std::fmt::Formatter<'_>,
+        num_vars: u64,
+        clauses: &Box<[Clause]>,
+    ) -> std::fmt::Result {
+        write!(f, "p cnf {} {}\n", num_vars, clauses.len())?;
+        for clause in clauses.iter() {
+            for literal in clause.lits() {
+                write!(f, "{} ", literal)?;
+            }
+            write!(f, "0\n")?;
+        }
+        Ok(())
     }
 
     /// Creates a SAT or CNF instance, converting it into a String
@@ -311,18 +327,18 @@ bitflags! {
     }
 }
 
-impl ToString for Extensions {
-    fn to_string(&self) -> String {
+impl Display for Extensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let eqxor = Extensions::EQ | Extensions::XOR;
         if *self == eqxor {
-            String::from("satex")
+            write!(f, "satex")
         } else {
-            String::from(match *self {
-                Extensions::NONE => "sat",
-                Extensions::XOR => "satx",
-                Extensions::EQ => "sate",
-                _ => "Illegal extension",
-            })
+            match *self {
+                Extensions::NONE => write!(f, "sat"),
+                Extensions::XOR => write!(f, "satx"),
+                Extensions::EQ => write!(f, "sate"),
+                _ => Err(std::fmt::Error::default()),
+            }
         }
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -343,7 +343,10 @@ mod tests {
             lexer.next(),
             Some(Ok(Token::new(Loc::new(6, 6), Ident(Cnf))))
         );
-        assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(6, 10), Nat(42)))));
+        assert_eq!(
+            lexer.next(),
+            Some(Ok(Token::new(Loc::new(6, 10), Nat(42))))
+        );
         assert_eq!(
             lexer.next(),
             Some(Ok(Token::new(Loc::new(6, 13), Nat(1337))))
@@ -369,7 +372,10 @@ mod tests {
         assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(10, 7), Minus))));
         assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(10, 8), Nat(8)))));
         assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(10, 10), Minus))));
-        assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(10, 11), Nat(9)))));
+        assert_eq!(
+            lexer.next(),
+            Some(Ok(Token::new(Loc::new(10, 11), Nat(9))))
+        );
         assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(10, 13), Zero))));
 
         assert_eq!(lexer.next(), None);
@@ -395,7 +401,10 @@ mod tests {
             lexer.next(),
             Some(Ok(Token::new(Loc::new(3, 6), Ident(Sat))))
         );
-        assert_eq!(lexer.next(), Some(Ok(Token::new(Loc::new(3, 10), Nat(42)))));
+        assert_eq!(
+            lexer.next(),
+            Some(Ok(Token::new(Loc::new(3, 10), Nat(42))))
+        );
         assert_eq!(
             lexer.next(),
             Some(Ok(Token::new(Loc::new(3, 13), Nat(1337))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod parser;
 
 pub use crate::errors::{ErrorKind, Loc, ParseError, Result};
 pub use crate::items::{
-    Clause, Extensions, Formula, FormulaBox, FormulaList, Instance, Lit, Sign, Var,
+    Clause, Extensions, Formula, FormulaBox, FormulaList, Instance, Lit, Sign,
+    Var,
 };
 pub use crate::parser::{parse_dimacs, read_dimacs};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,10 @@ where
     fn from(input: I) -> Parser<I> {
         Parser {
             tokens: ValidLexer::from(input),
-            peek: Err(ParseError::new(Loc::new(0, 0), ErrorKind::EmptyTokenStream)),
+            peek: Err(ParseError::new(
+                Loc::new(0, 0),
+                ErrorKind::EmptyTokenStream,
+            )),
         }
     }
 
@@ -93,7 +96,9 @@ where
         self.expect(Ident(Problem))?;
         match self.peek?.kind {
             Ident(Cnf) => self.parse_cnf_header(),
-            Ident(Sat) | Ident(Sate) | Ident(Satx) | Ident(Satex) => self.parse_sat_header(),
+            Ident(Sat) | Ident(Sate) | Ident(Satx) | Ident(Satex) => {
+                self.parse_sat_header()
+            }
             _ => self.err(ErrorKind::UnexpectedToken),
         }
     }
@@ -286,8 +291,6 @@ pub fn read_dimacs<R: Read>(input: R) -> Result<Instance> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
-
     use super::*;
 
     #[test]
@@ -308,7 +311,11 @@ mod tests {
             vec![
                 Clause::from_vec(vec![Lit::from_i64(1), Lit::from_i64(2)]),
                 Clause::from_vec(vec![Lit::from_i64(-3), Lit::from_i64(4)]),
-                Clause::from_vec(vec![Lit::from_i64(5), Lit::from_i64(-6), Lit::from_i64(7)]),
+                Clause::from_vec(vec![
+                    Lit::from_i64(5),
+                    Lit::from_i64(-6),
+                    Lit::from_i64(7),
+                ]),
                 Clause::from_vec(vec![
                     Lit::from_i64(-7),
                     Lit::from_i64(-8),
@@ -332,7 +339,11 @@ mod tests {
         let expected = Instance::cnf(
             4,
             vec![
-                Clause::from_vec(vec![Lit::from_i64(1), Lit::from_i64(3), Lit::from_i64(-4)]),
+                Clause::from_vec(vec![
+                    Lit::from_i64(1),
+                    Lit::from_i64(3),
+                    Lit::from_i64(-4),
+                ]),
                 Clause::from_vec(vec![Lit::from_i64(4)]),
                 Clause::from_vec(vec![Lit::from_i64(2), Lit::from_i64(-3)]),
             ],
@@ -386,7 +397,11 @@ mod tests {
             vec![
                 Clause::from_vec(vec![Lit::from_i64(1), Lit::from_i64(2)]),
                 Clause::from_vec(vec![Lit::from_i64(-3), Lit::from_i64(4)]),
-                Clause::from_vec(vec![Lit::from_i64(5), Lit::from_i64(-6), Lit::from_i64(7)]),
+                Clause::from_vec(vec![
+                    Lit::from_i64(5),
+                    Lit::from_i64(-6),
+                    Lit::from_i64(7),
+                ]),
                 Clause::from_vec(vec![
                     Lit::from_i64(-7),
                     Lit::from_i64(-8),
@@ -410,7 +425,11 @@ mod tests {
         let expected = Instance::cnf(
             4,
             vec![
-                Clause::from_vec(vec![Lit::from_i64(1), Lit::from_i64(3), Lit::from_i64(-4)]),
+                Clause::from_vec(vec![
+                    Lit::from_i64(1),
+                    Lit::from_i64(3),
+                    Lit::from_i64(-4),
+                ]),
                 Clause::from_vec(vec![Lit::from_i64(4)]),
                 Clause::from_vec(vec![Lit::from_i64(2), Lit::from_i64(-3)]),
             ],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,8 +12,10 @@ fn simple_cnf_serialize_1() {
         -3 4 0
         5 -6 7 0
         -7 -8 -9 0";
-    let comments = vec![String::from("Sample DIMACS.cnf file"),
-                        String::from("holding some information")];
+    let comments = vec![
+        String::from("Sample DIMACS.cnf file"),
+        String::from("holding some information"),
+    ];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
     let ser = parsed.serialize(&comments);
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
@@ -29,8 +31,10 @@ fn simple_cnf_serialize_2() {
         1 3 -4 0
         4 0 2
         -3";
-    let comments = vec![String::from("Sample DIMACS.cnf file"),
-                        String::from("holding some information")];
+    let comments = vec![
+        String::from("Sample DIMACS.cnf file"),
+        String::from("holding some information"),
+    ];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
     let ser = parsed.serialize(&comments);
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
@@ -45,8 +49,10 @@ fn simple_sat_seraizlie() {
         (*(+(1 3 -4)
         +(4)
         +(2 3)))";
-    let comments = vec![String::from("Sample DIMACS.cnf file"),
-                        String::from("holding some information")];
+    let comments = vec![
+        String::from("Sample DIMACS.cnf file"),
+        String::from("holding some information"),
+    ];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .sat");
     let ser = parsed.serialize(&comments);
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,11 +13,12 @@ fn simple_cnf_serialize_1() {
         5 -6 7 0
         -7 -8 -9 0";
     let comments = vec![
-        String::from("Sample DIMACS.cnf file"),
-        String::from("holding some information"),
+        "Sample DIMACS.cnf file",
+        "holding some information",
     ];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
-    let ser = parsed.serialize(&comments);
+    let mut ser = String::from("");
+    parsed.serialize(&comments, &mut ser).unwrap();
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
     assert_eq!(parsed, parsed2);
 }
@@ -32,11 +33,12 @@ fn simple_cnf_serialize_2() {
         4 0 2
         -3";
     let comments = vec![
-        String::from("Sample DIMACS.cnf file"),
-        String::from("holding some information"),
+        "Sample DIMACS.cnf file",
+        "holding some information",
     ];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
-    let ser = parsed.serialize(&comments);
+    let mut ser = String::from("");
+    parsed.serialize(&comments, &mut ser).unwrap();
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
     assert_eq!(parsed, parsed2);
 }
@@ -51,7 +53,8 @@ fn simple_sat_serialize() {
         +(2 3)))";
     let comments = vec![];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .sat");
-    let ser = parsed.serialize(&comments);
+    let mut ser = String::from("");
+    parsed.serialize(&comments, &mut ser).unwrap();
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .sat");
     assert_eq!(parsed, parsed2);
 }
@@ -66,7 +69,8 @@ fn xor_sat_serialize() {
         +(2 3)))";
     let comments = vec![];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .satx");
-    let ser = parsed.serialize(&comments);
+    let mut ser = String::from("");
+    parsed.serialize(&comments, &mut ser).unwrap();
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .satx");
     assert_eq!(parsed, parsed2);
 }
@@ -80,9 +84,8 @@ fn xoreq_sat_serialize() {
         =(2 3)))";
     let comments = vec![];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .satex");
-    let ser = parsed.serialize(&comments);
-    println!("parsed: {}", parsed);
-    println!("serialized: {}", ser);
+    let mut ser = String::from("");
+    parsed.serialize(&comments, &mut ser).unwrap();
     let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .satex");
     assert_eq!(parsed, parsed2);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,54 @@
+use dimacs::read_dimacs;
+
+#[test]
+fn simple_cnf_serialize_1() {
+    let sample = r"
+        c Sample DIMACS .cnf file
+        c holding some information
+        c and trying to be some
+        c kind of a test.
+        p cnf 42 1337
+        1 2 0
+        -3 4 0
+        5 -6 7 0
+        -7 -8 -9 0";
+    let comments = vec![String::from("Sample DIMACS.cnf file"),
+                        String::from("holding some information")];
+    let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
+    let ser = parsed.serialize(&comments);
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
+    assert_eq!(parsed, parsed2);
+}
+
+#[test]
+fn simple_cnf_serialize_2() {
+    let sample = r"
+        c Example CNF format file
+        c
+        p cnf 4 3
+        1 3 -4 0
+        4 0 2
+        -3";
+    let comments = vec![String::from("Sample DIMACS.cnf file"),
+                        String::from("holding some information")];
+    let parsed = read_dimacs(sample.as_bytes()).expect("valid .cnf");
+    let ser = parsed.serialize(&comments);
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
+    assert_eq!(parsed, parsed2);
+}
+
+#[test]
+fn simple_sat_seraizlie() {
+    let sample = r"
+        c Sample DIMACS .sat file
+        p sat 42
+        (*(+(1 3 -4)
+        +(4)
+        +(2 3)))";
+    let comments = vec![String::from("Sample DIMACS.cnf file"),
+                        String::from("holding some information")];
+    let parsed = read_dimacs(sample.as_bytes()).expect("valid .sat");
+    let ser = parsed.serialize(&comments);
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
+    assert_eq!(parsed, parsed2);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -42,19 +42,47 @@ fn simple_cnf_serialize_2() {
 }
 
 #[test]
-fn simple_sat_seraizlie() {
+fn simple_sat_serialize() {
     let sample = r"
         c Sample DIMACS .sat file
         p sat 42
         (*(+(1 3 -4)
         +(4)
         +(2 3)))";
-    let comments = vec![
-        String::from("Sample DIMACS.cnf file"),
-        String::from("holding some information"),
-    ];
+    let comments = vec![];
     let parsed = read_dimacs(sample.as_bytes()).expect("valid .sat");
     let ser = parsed.serialize(&comments);
-    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .cnf");
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .sat");
+    assert_eq!(parsed, parsed2);
+}
+
+#[test]
+fn xor_sat_serialize() {
+    let sample = r"
+        c Sample DIMACS .satx file
+        p satx 42
+        (xor(+(1 3 -4)
+        +(4)
+        +(2 3)))";
+    let comments = vec![];
+    let parsed = read_dimacs(sample.as_bytes()).expect("valid .satx");
+    let ser = parsed.serialize(&comments);
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .satx");
+    assert_eq!(parsed, parsed2);
+}
+#[test]
+fn xoreq_sat_serialize() {
+    let sample = r"
+        c Sample DIMACS .satex file
+        p satex 42
+        (xor(+(1 3 -4)
+        +(4)
+        =(2 3)))";
+    let comments = vec![];
+    let parsed = read_dimacs(sample.as_bytes()).expect("valid .satex");
+    let ser = parsed.serialize(&comments);
+    println!("parsed: {}", parsed);
+    println!("serialized: {}", ser);
+    let parsed2 = read_dimacs(ser.as_bytes()).expect("valid .satex");
     assert_eq!(parsed, parsed2);
 }


### PR DESCRIPTION
Serialization API has two functions.

First, implemented trait `ToString` for `Instance`

Second, the `pub fn serialize(&self, comments: &Vec<string>)` function allows the user to add comments to the preamble.

I also fixed some minor complaints from rustc, and applied 80-char line width.